### PR TITLE
Use brokets for bare URL links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 In my copious free time, I populate this web site.
 
-* [https://tripleee.github.io/8bit/](https://tripleee.github.io/8bit/)
+* <https://tripleee.github.io/8bit/>
   - helper document for discovering the encoding of an 8-bit text file
-* [https://tripleee.github.io/ms-bookmarklets/](https://tripleee.github.io/ms-bookmarklets/)
+* <https://tripleee.github.io/ms-bookmarklets/>
   - Javascript bookmarklets for [metasmoke](https://metasmoke.erwaysoftware.com)
   
 No license. This is copyrighted content.


### PR DESCRIPTION
As suggested in https://talk.jekyllrb.com/t/bare-url-in-markdown-loses-its-link/7602/6?u=tripleee